### PR TITLE
(Fixes #24) Upgrade to hyperion v5.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val awsSdkVersion = "1.11.238"
+val awsSdkVersion = "1.11.486"
 val slickVersion = "3.2.3"
 
 val scalaTestArtifact      = "org.scalatest"          %% "scalatest"            % "3.0.5" % "test"
@@ -7,7 +7,7 @@ val slickHikaricpArtifact  = "com.typesafe.slick"     %% "slick-hikaricp"       
 val scoptArtifact          = "com.github.scopt"       %% "scopt"                % "3.7.0"
 val configArtifact         = "com.typesafe"           %  "config"               % "1.3.3"
 val nscalaTimeArtifact     = "com.github.nscala-time" %% "nscala-time"          % "2.18.0"
-val hyperionArtifact       = "com.krux"               %% "hyperion"             % "5.1.6"
+val hyperionArtifact       = "com.krux"               %% "hyperion"             % "5.3.0"
 val slf4jApiArtifact       = "org.slf4j"              %  "slf4j-api"            % "1.7.12"
 val logbackClassicArtifact = "ch.qos.logback"         %  "logback-classic"      % "1.1.7"
 val awsSdkS3               = "com.amazonaws"          %  "aws-java-sdk-s3"      % awsSdkVersion
@@ -19,7 +19,7 @@ val postgreSqlJdbc         = "org.postgresql"         %  "postgresql"           
 
 lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.8",
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",
   test in assembly := {},  // skip test during assembly

--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
@@ -159,29 +159,44 @@ object SubmitPipeline extends DateTimeFunctions with WaitForIt with DateTimeMapp
         }
       }
 
+      // Because we are using schedule from CLI it will always be Left of the HDateTime
+      // This is a hacky way of solving the incompatibility of hyperion 5.3.0 that changes
+      // scheduling start time from joda DateTime to HDateTime
+      def getStartTimeFromSchedule(schedule: RecurringSchedule): DateTime = {
+        require(schedule.start.isDefined && schedule.start.get.value.isLeft, "Starport does not work with empty or expression based start time")
+        schedule.start.get.value.left.get.withZone(DateTimeZone.UTC)
+      }
+
+      def getPeriodFromSchedule(schedule: RecurringSchedule): Period = {
+        require(schedule.period.value.isLeft, "Starport does not work with expression based period")
+        schedule.period.value.left.get
+      }
+
+
       // load the class from the jar and print the schedule
       // val jars = Array(new File(cli.jar).toURI.toURL)
       val jarFile = S3FileHandler.getFileFromS3(cli.jar, cli.baseDir)
       if (cli.cleanUp) jarFile.deleteOnExit
 
-      val (period, start) = (cli.frequency, cli.schedule) match {
+      val (period, start): (Period, DateTime) = (cli.frequency, cli.schedule) match {
         case (Some(freq), Some(schedule)) =>
           val specifiedSchedule = Schedule
             .cron
             .startDateTime(schedule)
             .every(freq)
-          (specifiedSchedule.period, specifiedSchedule.start.get.withZone(DateTimeZone.UTC))
+
+          (getPeriodFromSchedule(specifiedSchedule), getStartTimeFromSchedule(specifiedSchedule))
         case x =>
           // if the schedule or frequency are not specified then instantiate the pipeline object and read the schedule variable
           val pipelineSchedule = getPipelineSchedule(jarFile, cli)
           // if 'one' of the parameters(schedule / frequency) is specified, then it will override the pipeline's definition of that param
           x match {
             case (Some(freq), None) =>
-              (freq, pipelineSchedule.start.get.withZone(DateTimeZone.UTC))
+              (freq, getStartTimeFromSchedule(pipelineSchedule))
             case (None, Some(schedule)) =>
-              (pipelineSchedule.period, schedule)
+              (getPeriodFromSchedule(pipelineSchedule), schedule)
             case _ =>
-              (pipelineSchedule.period, pipelineSchedule.start.getOrElse(DateTime.now).withZone(DateTimeZone.UTC))
+              (getPeriodFromSchedule(pipelineSchedule), getStartTimeFromSchedule(pipelineSchedule))
           }
       }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.2.0"
+version in ThisBuild := "5.3.0"


### PR DESCRIPTION
- Hyperion 5.3.0 is a breaking change, this would require all managed
    pipeline to upgrade to 5.3.0 so that submit pipeline tool would work
    propoerly, if submit pipeline tool is not a critical workflow, then this
    starport wuold continue to work