### PR TITLE
fix lambda stdout/stderr

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.4.2"
+version in ThisBuild := "5.4.3"


### PR DESCRIPTION
This was working before! Perhaps AWS changed something in the Lambda runtime, or I didn't test things well enough. Regardless, I moved the initialization of the IO into static areas, following these [best practices](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html):

> Limit the re-initialization of variables/objects on every invocation. Instead use static initialization/constructor, global/static variables and singletons. Keep alive and reuse connections (HTTP, database, etc.) that were established during a previous invocation.

Additionally, I'm no longer switching the original stdout/stderr back. These stay re-assigned for the duration of the lambda lifetime. However, I am still printing to the original stderr/stdout so that data appears in cloudwatch logs.
