### PR TITLE
Allow updating the jar only for deployment purposes

### DIFF
--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipelineOptionParser.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipelineOptionParser.scala
@@ -37,6 +37,10 @@ object SubmitPipelineOptionParser extends Reads with Logging {
               |        (if it's previously disabled) instead of insert""".stripMargin)
       .optional()
 
+    opt[Unit]("update-jar-only").action((_, c) => c.copy(updateJarOnly = true))
+      .text("when updating (-u) only update the jar name/location. Use to semantically version jars during deployment")
+      .optional()
+
     opt[Unit]("no-backfill").action((_, c) => c.copy(noBackfill = true))
       .text("do not perform any backfill when scheduling")
       .optional()

--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipelineOptions.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipelineOptions.scala
@@ -9,6 +9,7 @@ case class SubmitPipelineOptions(
   pipelineObject: String = "",
   startNow: Boolean = false,
   update: Boolean = false,
+  updateJarOnly: Boolean = true,
   noBackfill: Boolean = false,
   baseDir: Option[String] = None,
   cleanUp: Boolean = false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.5.2"
+version in ThisBuild := "5.6.0"


### PR DESCRIPTION
This allows updating an existing pipelines jar only:

```
$ sbt ";project core;runMain com.krux.starport.db.tool.SubmitPipeline -j s3://my-s3-bucket/jars/my-pipeline-assembly-0.4.2.jar --update --update-jar-only --pipeline com.myco.MyPipeline --owner me@myco.com"
```