### PR TITLE
[5.8.0] Add force option to cleanup managed pipelines too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val awsLambdaEvents        = "com.amazonaws"          %  "aws-lambda-java-events
 val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core"   % "1.2.0"
 
 lazy val commonSettings = Seq(
-  scalacOptions ++= Seq("-deprecation", "-feature" , "-Xlint", "-Xfatal-warnings"),
+  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
   scalaVersion := "2.12.8",
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val awsLambdaEvents        = "com.amazonaws"          %  "aws-lambda-java-events
 val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core"   % "1.2.0"
 
 lazy val commonSettings = Seq(
-  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
+  scalacOptions ++= Seq("-deprecation", "-feature" , "-Xlint", "-Xfatal-warnings"),
   scalaVersion := "2.12.8",
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",

--- a/starport-core/src/main/scala/com/krux/starport/cli/CleanupNonStarportOptionParser.scala
+++ b/starport-core/src/main/scala/com/krux/starport/cli/CleanupNonStarportOptionParser.scala
@@ -21,6 +21,9 @@ object CleanupNonStarportOptionParser extends Reads {
 
     opt[Unit]("dryRun").valueName("<dryRun>")
       .action((_, c) => c.copy(dryRun = true))
+
+    opt[Unit]("force").valueName("<force> will ignore if the pipeline is managed by starport or not")
+      .action((_, c) => c.copy(force = true))
   }
 
   def parse(args: Array[String]): Option[CleanupNonStarportOptions] = apply().parse(args, CleanupNonStarportOptions())

--- a/starport-core/src/main/scala/com/krux/starport/cli/CleanupNonStarportOptions.scala
+++ b/starport-core/src/main/scala/com/krux/starport/cli/CleanupNonStarportOptions.scala
@@ -7,5 +7,6 @@ import com.krux.starport.util.PipelineState
 case class CleanupNonStarportOptions(
   pipelineState: PipelineState.State = PipelineState.FINISHED,
   cutoffDate: DateTime = DateTime.now.minusMonths(2).withTimeAtStartOfDay,
+  force: Boolean = false,
   dryRun: Boolean = false
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.7.0"
+version in ThisBuild := "5.8.0"


### PR DESCRIPTION
CleanupNonStarportPipelines now supports a `--force` option when
specified, it will delete the pipelines that satisfy the condition even
if they are managed by starport. It is useful to delete stall and stuck
pipelines in AWS Data Pipeline.