### PR TITLE
Return tmp file listing from lambda

### DIFF
--- a/starport-core/src/main/scala/com/krux/starport/ErrorExit.scala
+++ b/starport-core/src/main/scala/com/krux/starport/ErrorExit.scala
@@ -27,9 +27,4 @@ object ErrorExit {
     System.exit(4)
   }
 
-  def failedScheduleExtraction(logger: Logger): Unit = {
-    logger.error("Failed to extract pipeline schedule from JAR file")
-    System.exit(5)
-  }
-
 }

--- a/starport-core/src/main/scala/com/krux/starport/ErrorExit.scala
+++ b/starport-core/src/main/scala/com/krux/starport/ErrorExit.scala
@@ -27,4 +27,9 @@ object ErrorExit {
     System.exit(4)
   }
 
+  def failedScheduleExtraction(logger: Logger): Unit = {
+    logger.error("Failed to extract pipeline schedule from JAR file")
+    System.exit(5)
+  }
+
 }

--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
@@ -3,6 +3,8 @@ package com.krux.starport.db.tool
 import java.io.File
 import java.net.URLClassLoader
 
+import scala.util.Try
+
 import com.github.nscala_time.time.Imports._
 import slick.jdbc.PostgresProfile.api._
 
@@ -79,11 +81,6 @@ object SubmitPipeline extends DateTimeFunctions with WaitForIt with DateTimeMapp
       schedule.period.value.left.get
     }
 
-    // load the class from the jar and print the schedule
-    // val jars = Array(new File(opts.jar).toURI.toURL)
-    val jarFile = S3FileHandler.getFileFromS3(opts.jar, opts.baseDir)
-    if (opts.cleanUp) jarFile.deleteOnExit
-
     val (period, start): (Duration, DateTime) = (opts.frequency, opts.schedule) match {
       case (Some(freq), Some(schedule)) =>
         val specifiedSchedule = Schedule
@@ -93,16 +90,27 @@ object SubmitPipeline extends DateTimeFunctions with WaitForIt with DateTimeMapp
 
         (getPeriodFromSchedule(specifiedSchedule), getStartTimeFromSchedule(specifiedSchedule))
       case x =>
+        val jarFile = S3FileHandler.getFileFromS3(opts.jar, opts.baseDir)
         // if the schedule or frequency are not specified then instantiate the pipeline object and read the schedule variable
-        val pipelineSchedule = getPipelineSchedule(jarFile, opts)
+        val pipelineSchedule = Try(getPipelineSchedule(jarFile, opts))
+        if (opts.cleanUp) {
+          logger.info("Cleaning up JAR file...")
+          jarFile.delete()
+        }
+        if (pipelineSchedule.isFailure) {
+          val e = pipelineSchedule.failed.get
+          logger.error(s"${e.getMessage}:\n${e.getStackTrace.mkString("\n")}")
+          ErrorExit.failedScheduleExtraction(logger)
+        }
+        val ps = pipelineSchedule.get
         // if 'one' of the parameters(schedule / frequency) is specified, then it will override the pipeline's definition of that param
         x match {
           case (Some(freq), None) =>
-            (freq, getStartTimeFromSchedule(pipelineSchedule))
+            (freq, getStartTimeFromSchedule(ps))
           case (None, Some(schedule)) =>
-            (getPeriodFromSchedule(pipelineSchedule), schedule)
+            (getPeriodFromSchedule(ps), schedule)
           case _ =>
-            (getPeriodFromSchedule(pipelineSchedule), getStartTimeFromSchedule(pipelineSchedule))
+            (getPeriodFromSchedule(ps), getStartTimeFromSchedule(ps))
         }
     }
 

--- a/starport-lambda/src/main/scala/com/krux/starport/lambda/SubmitHandler.scala
+++ b/starport-lambda/src/main/scala/com/krux/starport/lambda/SubmitHandler.scala
@@ -1,7 +1,6 @@
 package com.krux.starport.lambda
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
+import java.io.{ByteArrayOutputStream, File, PrintStream}
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 
@@ -40,10 +39,12 @@ class SubmitHandler extends RequestHandler[SubmitRequest, SubmitResponse] with L
       case caughtExit: LambdaExitException => {
         status = caughtExit.status
         logger.error("exit:", caughtExit)
+        logger.error(scanTmpFiles())
       }
       case unhandled: Throwable =>  {
         status = 255
         logger.error("exception:", unhandled)
+        logger.error(scanTmpFiles())
       }
     } finally {
       outPrintStream.flush()
@@ -57,6 +58,16 @@ class SubmitHandler extends RequestHandler[SubmitRequest, SubmitResponse] with L
     }
 
     SubmitResponse(outString, errString, status, input)
+  }
+
+  /**
+   * @return /tmp file listing with size for troubleshooting purposes
+   */
+  private def scanTmpFiles(): String = {
+    new File("/tmp")
+      .listFiles()
+      .map(f => s"${f.getAbsolutePath}: ${f.length()}")
+      .mkString("\n")
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.9.5"
+version in ThisBuild := "5.9.6"


### PR DESCRIPTION
~1. Delete jar file immediately after extracting schedule.~
2. Only download jar file when schedule is not specified through options.
~3. Add new exit error code for exception during schedule extraction.~
4. Return tmp file listing from lambda for troubleshooting