### PR TITLE
Clean up Jar immediately after schedule extraction

### DIFF
--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
@@ -40,7 +40,7 @@ object SubmitPipeline extends DateTimeFunctions with WaitForIt with DateTimeMapp
   private def cleanupJar(jarFile: File, opts: SubmitPipelineOptions): Unit = {
     if (opts.cleanUp) {
       logger.info(s"Cleaning up JAR file...")
-      jarFile.deleteOnExit()
+      jarFile.deleteOnExit() // In case of some uncaught exceptions, this will clean up the file at JVM level.
       jarFile.delete()
     } else {
       logger.info(s"Skipping JAR cleanup...")

--- a/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
+++ b/starport-core/src/main/scala/com/krux/starport/db/tool/SubmitPipeline.scala
@@ -89,9 +89,12 @@ object SubmitPipeline extends DateTimeFunctions with WaitForIt with DateTimeMapp
         (getPeriodFromSchedule(specifiedSchedule), getStartTimeFromSchedule(specifiedSchedule))
       case x =>
         val jarFile = S3FileHandler.getFileFromS3(opts.jar, opts.baseDir)
-        if (opts.cleanUp) jarFile.deleteOnExit()
         // if the schedule or frequency are not specified then instantiate the pipeline object and read the schedule variable
         val pipelineSchedule = getPipelineSchedule(jarFile, opts)
+        if (opts.cleanUp) {
+          jarFile.deleteOnExit()
+          jarFile.delete()
+        }
         // if 'one' of the parameters(schedule / frequency) is specified, then it will override the pipeline's definition of that param
         x match {
           case (Some(freq), None) =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.9.6"
+version in ThisBuild := "5.9.7"


### PR DESCRIPTION
There has been a bug where Starport Lambda does not clean up Jar file properly. The current implementation uses `.deleteOnExit` which does not seem to behave as expected on AWS Lambda. To mitigate this, we should call `.delete` to delete the Jar file immediately.