### PR TITLE
[W-6873353] Add CloudWatch metrics engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,16 +23,12 @@ val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core" 
 val cloudwatchMetrics      = "io.github.azagniotov"   %  "dropwizard-metrics-cloudwatch" % "1.0.13"
 
 lazy val commonSettings = Seq(
-  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
+  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint"),
   scalaVersion := "2.12.8",
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",
   test in assembly := {},  // skip test during assembly
   publishMavenStyle := true
-  //assemblyMergeStrategy in assembly := {
-  //  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  //  case x => MergeStrategy.first
- // }
 )
 
 lazy val root = (project in file(".")).

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,13 @@ val awsSdkS3               = "com.amazonaws"          %  "aws-java-sdk-s3"      
 val awsSdkSES              = "com.amazonaws"          %  "aws-java-sdk-ses"     % awsSdkVersion
 val awsSdkSSM              = "com.amazonaws"          %  "aws-java-sdk-ssm"     % awsSdkVersion
 val awsSdkSNS              = "com.amazonaws"          %  "aws-java-sdk-sns"     % awsSdkVersion
+val awsSdkCloudWatch       = "com.amazonaws"          %  "aws-java-sdk-cloudwatch"     % awsSdkVersion
 val stubbornArtifact       = "com.krux"               %% "stubborn"             % "1.3.0"
 val metricsGraphite        = "io.dropwizard.metrics"  %  "metrics-graphite"     % "4.0.2"
 val postgreSqlJdbc         = "org.postgresql"         %  "postgresql"           % "42.2.4"
 val awsLambdaEvents        = "com.amazonaws"          %  "aws-lambda-java-events" % "2.2.1"
 val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core"   % "1.2.0"
-val cloudwatchMetrics      = "io.github.azagniotov"   %  "dropwizard-metrics-cloudwatch" % "2.0.2"
+val cloudwatchMetrics      = "io.github.azagniotov"   %  "dropwizard-metrics-cloudwatch" % "1.0.13"
 
 lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
@@ -27,11 +28,11 @@ lazy val commonSettings = Seq(
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",
   test in assembly := {},  // skip test during assembly
-  publishMavenStyle := true,
-  assemblyMergeStrategy in assembly := {
-    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-    case x => MergeStrategy.first
-  }
+  publishMavenStyle := true
+  //assemblyMergeStrategy in assembly := {
+  //  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  //  case x => MergeStrategy.first
+ // }
 )
 
 lazy val root = (project in file(".")).
@@ -61,6 +62,7 @@ lazy val core = (project in file("starport-core")).
       awsSdkSES,
       awsSdkSSM,
       awsSdkSNS,
+      awsSdkCloudWatch,
       stubbornArtifact,
       metricsGraphite,
       postgreSqlJdbc,

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val metricsGraphite        = "io.dropwizard.metrics"  %  "metrics-graphite"     
 val postgreSqlJdbc         = "org.postgresql"         %  "postgresql"           % "42.2.4"
 val awsLambdaEvents        = "com.amazonaws"          %  "aws-lambda-java-events" % "2.2.1"
 val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core"   % "1.2.0"
+val cloudwatchMetrics      = "io.github.azagniotov"   %  "dropwizard-metrics-cloudwatch" % "2.0.2"
 
 lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
@@ -58,7 +59,8 @@ lazy val core = (project in file("starport-core")).
       awsSdkSNS,
       stubbornArtifact,
       metricsGraphite,
-      postgreSqlJdbc
+      postgreSqlJdbc,
+      cloudwatchMetrics
     ),
     fork := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val awsLambdaCore          = "com.amazonaws"          %  "aws-lambda-java-core" 
 val cloudwatchMetrics      = "io.github.azagniotov"   %  "dropwizard-metrics-cloudwatch" % "1.0.13"
 
 lazy val commonSettings = Seq(
-  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint"),
+  scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings"),
   scalaVersion := "2.12.8",
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,11 @@ lazy val commonSettings = Seq(
   libraryDependencies += scalaTestArtifact,
   organization := "com.krux",
   test in assembly := {},  // skip test during assembly
-  publishMavenStyle := true
+  publishMavenStyle := true,
+  assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+    case x => MergeStrategy.first
+  }
 )
 
 lazy val root = (project in file(".")).

--- a/conf-template/starport.conf
+++ b/conf-template/starport.conf
@@ -7,14 +7,14 @@ krux.starport {
     prefix = "sp_"
 
     # the starport jar to be deployed replace this with valid s3 uri
-    jar.url = ??? # "s3://some-fake-bucket/starport-core-assembly-current.jar"
+    jar.url = "???" # "s3://some-fake-bucket/starport-core-assembly-current.jar"
 
     notification {
         # sns notifications to be sent when starport fails
-        sns = ??? # "arn:aws:sns:<region>:<account-id>:<topic-name>"
+        sns = "???" # "arn:aws:sns:<region>:<account-id>:<topic-name>"
         email {
-            from = ??? # no-reply@myco.com
-            to = [???] # [ "tellme@myco.com", "tellme2@myco.com" ]
+            from = "???" # no-reply@myco.com
+            to = ["???"] # [ "tellme@myco.com", "tellme2@myco.com" ]
         }
     }
     jdbc {
@@ -23,9 +23,9 @@ krux.starport {
             connectionPool = disabled
             properties = {
                 databaseName = "starport"  # the database name to use
-                serverName = ???  # the database host name
-                user = ???  # the database username
-                password = ??? # the password
+                serverName = "???"  # the database host name
+                user = "???"  # the database username
+                password = "???" # the password
             }
         }
     }
@@ -43,7 +43,7 @@ krux.starport {
     }
 
     # slack webhook to be used (optional)
-    slack_webhook_url = ???
+    slack_webhook_url = "???"
 
     # metrics engine (optional)
     # Valid values: null, "graphite", "cloudwatch"
@@ -68,13 +68,15 @@ krux.starport {
     # cloudwatch integration (optional)
     metric.cloudwatch {
 
-        region = ???
-        environment = ???
-        group = ???
-        module = ???
-        name = ???
-        stack = ???
-        terraform = ???
+      region = "us-west-2"
+
+      "Dimensions" : {
+
+          "Environment" : "???"
+          "Stack" : "???"
+          "Name" : "???"
+
+      }
 
     }
 
@@ -92,12 +94,12 @@ hyperion {
         # the ec2 instance configuration to be used to run starport processes
         ec2 {
             instance.type = "m3.medium"
-            securitygroup = ???  # the security group
+            securitygroup = "???"  # the security group
             terminate = "1 hours"  # try not to change this one
             image {
                 # Make sure it's AWS data pipeline compatible image and the AMI
                 # is configured to use Java 8 by default
-                us-east-1 = ???  # the AMI
+                us-east-1 = "???"  # the AMI
             }
         }
     }

--- a/conf-template/starport.conf
+++ b/conf-template/starport.conf
@@ -66,7 +66,17 @@ krux.starport {
     }
 
     # cloudwatch integration (optional)
-    metric.cloudwatch { }
+    metric.cloudwatch {
+
+        region = ???
+        environment = ???
+        group = ???
+        module = ???
+        name = ???
+        stack = ???
+        terraform = ???
+
+    }
 
 }
 

--- a/conf-template/starport.conf
+++ b/conf-template/starport.conf
@@ -68,8 +68,10 @@ krux.starport {
     # cloudwatch integration (optional)
     metric.cloudwatch {
 
-      region = "us-west-2"
+      # Specify the region to report to.
+      region = null
 
+      # An optional list of dimensions to report to Cloudwatch for filtering.
       "Dimensions" : {
 
           "Environment" : "???"

--- a/conf-template/starport.conf
+++ b/conf-template/starport.conf
@@ -66,13 +66,7 @@ krux.starport {
     }
 
     # cloudwatch integration (optional)
-    metric.cloudwatch {
-
-        environment = ???
-        region = ???
-        key = ???
-
-    }
+    metric.cloudwatch { }
 
 }
 

--- a/conf-template/starport.conf
+++ b/conf-template/starport.conf
@@ -45,6 +45,11 @@ krux.starport {
     # slack webhook to be used (optional)
     slack_webhook_url = ???
 
+    # metrics engine (optional)
+    # Valid values: null, "graphite", "cloudwatch"
+    # Note that only one option can be specified
+    metric.engine = null
+
     # graphite integration (optional)
     metric.graphite {
         # the graphite hosts
@@ -59,6 +64,16 @@ krux.starport {
         # the metric prefix to be used
         prefix = "stats.prod.starport"
     }
+
+    # cloudwatch integration (optional)
+    metric.cloudwatch {
+
+        environment = ???
+        region = ???
+        key = ???
+
+    }
+
 }
 
 # Starport rely hyperion to run, here are some sample hyperion configurations

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
@@ -156,7 +156,7 @@ object CleanupExistingPipelines extends StarportActivity {
 
   def main(args: Array[String]): Unit = {
 
-    val reporter = conf.metricSettings match {
+    val reporter = conf.metricConfig match {
       case Some(config) => reportingEngine.getReporter(config, metrics)
       case None => reportingEngine.getDefaultReporter(metrics)
     }

--- a/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
@@ -3,12 +3,11 @@ package com.krux.starport
 import com.codahale.metrics.MetricRegistry
 import com.github.nscala_time.time.Imports._
 import slick.jdbc.PostgresProfile.api._
-
 import com.krux.hyperion.client.{AwsClient, AwsClientForId}
 import com.krux.starport.db.record.FailedPipeline
 import com.krux.starport.db.table.{FailedPipelines, Pipelines, ScheduledPipelines}
-import com.krux.starport.metric.{ConstantValueGauge, MetricSettings}
-import com.krux.starport.util.{AwsDataPipeline, PipelineState, ErrorHandler}
+import com.krux.starport.metric.{ConstantValueGauge, GraphiteReporterSettings}
+import com.krux.starport.util.{AwsDataPipeline, ErrorHandler, PipelineState}
 
 
 /**
@@ -155,7 +154,7 @@ object CleanupExistingPipelines extends StarportActivity {
 
   def main(args: Array[String]): Unit = {
 
-    val reporter = MetricSettings.getReporter(conf.metricSettings, metrics)
+    val reporter = GraphiteReporterSettings.getReporter(conf.metricSettings, metrics)
 
     val start = System.nanoTime
     try {

--- a/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
@@ -156,10 +156,7 @@ object CleanupExistingPipelines extends StarportActivity {
 
   def main(args: Array[String]): Unit = {
 
-    val reporter = conf.metricConfig match {
-      case Some(config) => reportingEngine.getReporter(config, metrics)
-      case None => reportingEngine.getDefaultReporter(metrics)
-    }
+    val reporter = reportingEngine.getReporter(conf.metricConfig, metrics)
 
     val start = System.nanoTime
     try {

--- a/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
@@ -15,7 +15,7 @@ import com.krux.hyperion.expression.{Duration => HDuration}
 import com.krux.starport.cli.{SchedulerOptions, SchedulerOptionParser}
 import com.krux.starport.db.record.{Pipeline, ScheduledPipeline, SchedulerMetric}
 import com.krux.starport.db.table.{ScheduledPipelines, Pipelines, SchedulerMetrics, ScheduleFailureCounters}
-import com.krux.starport.metric.{ConstantValueGauge, SimpleTimerGauge, MetricSettings}
+import com.krux.starport.metric.{ConstantValueGauge, SimpleTimerGauge, GraphiteReporterSettings}
 import com.krux.starport.util.{S3FileHandler, ErrorHandler}
 
 
@@ -263,7 +263,7 @@ object StartScheduledPipelines extends StarportActivity {
     val mainTimer = new SimpleTimerGauge(TimeUnit.MINUTES)
     metrics.register("gauges.runtime", mainTimer)
 
-    val reporter = MetricSettings.getReporter(conf.metricSettings, metrics)
+    val reporter = GraphiteReporterSettings.getReporter(conf.metricSettings, metrics)
 
     try {
       SchedulerOptionParser.parse(args) match {

--- a/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
@@ -267,10 +267,7 @@ object StartScheduledPipelines extends StarportActivity {
     val mainTimer = new SimpleTimerGauge(TimeUnit.MINUTES)
     metrics.register("gauges.runtime", mainTimer)
 
-    val reporter = conf.metricConfig match {
-      case Some(config) => reportingEngine.getReporter(config, metrics)
-      case None => reportingEngine.getDefaultReporter(metrics)
-    }
+    val reporter = reportingEngine.getReporter(conf.metricConfig, metrics)
 
     try {
       SchedulerOptionParser.parse(args) match {

--- a/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
@@ -262,7 +262,7 @@ object StartScheduledPipelines extends StarportActivity {
     val mainTimer = new SimpleTimerGauge(TimeUnit.MINUTES)
     metrics.register("gauges.runtime", mainTimer)
 
-    val reporter = conf.metricSettings match {
+    val reporter = conf.metricConfig match {
       case Some(config) => reportingEngine.getReporter(config, metrics)
       case None => reportingEngine.getDefaultReporter(metrics)
     }

--- a/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
@@ -19,7 +19,7 @@ class StarportSettings(val config: Config) extends Serializable {
   val starportNotificationSns = config.getString("krux.starport.notification.sns")
 
   val metricsEngine: MetricSettings =
-    Try(config.getConfig("krux.starport.metric.engine")) match {
+    Try(config.getString("krux.starport.metric.engine")) match {
       case Success(engine) => engine match {
         case s if (s == "graphite") => GraphiteReporterSettings
         case s if (s == "cloudwatch") => CloudWatchReporterSettings
@@ -27,7 +27,7 @@ class StarportSettings(val config: Config) extends Serializable {
       case Failure(_) => throw new InstantiationException("No metrics engine specified.")
     }
 
-  val metricSettings: Option[Config] = metricsEngine match {
+  val metricConfig: Option[Config] = metricsEngine match {
       case GraphiteReporterSettings => Try(config.getConfig("krux.starport.metric.graphite")).toOption
       case CloudWatchReporterSettings => Try(config.getConfig("krux.starport.metric.cloudwatch")).toOption
    }

--- a/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
@@ -4,13 +4,11 @@ import java.net.URL
 
 import scala.collection.JavaConverters._
 import scala.collection.{Map => IMap}
-import scala.util.Try
-
+import scala.util.{Failure, Success, Try}
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueType}
 import com.amazonaws.regions.Regions
-
+import com.krux.starport.metric.{CloudWatchReporterSettings, GraphiteReporterSettings, MetricSettings}
 import com.krux.starport.net.StarportURLStreamHandlerFactory
-
 
 class StarportSettings(val config: Config) extends Serializable {
 
@@ -20,8 +18,19 @@ class StarportSettings(val config: Config) extends Serializable {
 
   val starportNotificationSns = config.getString("krux.starport.notification.sns")
 
-  val metricSettings: Option[Config] =
-    Try(config.getConfig("krux.starport.metric.graphite")).toOption
+  val metricsEngine: MetricSettings =
+    Try(config.getConfig("krux.starport.metric.engine")) match {
+      case Success(engine) => engine match {
+        case s if (s == "graphite") => GraphiteReporterSettings
+        case s if (s == "cloudwatch") => CloudWatchReporterSettings
+      }
+      case Failure(_) => throw new InstantiationException("No metrics engine specified.")
+    }
+
+  val metricSettings: Option[Config] = metricsEngine match {
+      case GraphiteReporterSettings => Try(config.getConfig("krux.starport.metric.graphite")).toOption
+      case CloudWatchReporterSettings => Try(config.getConfig("krux.starport.metric.cloudwatch")).toOption
+   }
 
   val jdbc: JdbcConfig = JdbcConfig(config.getConfig("krux.starport.jdbc"))
 

--- a/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/config/StarportSettings.scala
@@ -7,7 +7,7 @@ import scala.collection.{Map => IMap}
 import scala.util.{Failure, Success, Try}
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueType}
 import com.amazonaws.regions.Regions
-import com.krux.starport.metric.{CloudWatchReporterSettings, GraphiteReporterSettings, MetricSettings}
+import com.krux.starport.metric.{CloudWatchReporterSettings, DefaultConsoleReporterSettings, GraphiteReporterSettings, MetricSettings}
 import com.krux.starport.net.StarportURLStreamHandlerFactory
 
 class StarportSettings(val config: Config) extends Serializable {
@@ -24,12 +24,13 @@ class StarportSettings(val config: Config) extends Serializable {
         case s if (s == "graphite") => GraphiteReporterSettings
         case s if (s == "cloudwatch") => CloudWatchReporterSettings
       }
-      case Failure(_) => throw new InstantiationException("No metrics engine specified.")
+      case Failure(_) => DefaultConsoleReporterSettings
     }
 
   val metricConfig: Option[Config] = metricsEngine match {
       case GraphiteReporterSettings => Try(config.getConfig("krux.starport.metric.graphite")).toOption
       case CloudWatchReporterSettings => Try(config.getConfig("krux.starport.metric.cloudwatch")).toOption
+      case DefaultConsoleReporterSettings => None
    }
 
   val jdbc: JdbcConfig = JdbcConfig(config.getConfig("krux.starport.jdbc"))

--- a/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
@@ -2,8 +2,6 @@ package com.krux.starport.metric
 
 import java.util.concurrent.TimeUnit
 
-import com.amazonaws.auth.SdkClock.Instance
-
 import scala.util.Random
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.codahale.metrics.{ConsoleReporter, MetricFilter, MetricRegistry, ScheduledReporter}
@@ -75,8 +73,8 @@ final case object CloudWatchReporterSettings extends MetricSettings {
 
   private case class CloudWatchReporterSettingsImpl(config: Config) extends MetricSettingsImpl {
 
-    val awsRegion: Region = config.getString("region").toString.asInstanceOf[Region]
-    val awsEnvironment: Instance = config.getString("environment").toString.asInstanceOf[Instance]
+    val awsRegion: Region = config.getString("region").asInstanceOf[Region]
+    val awsEnvironment = config.getString("environment")
 
     val awsCloudWatchAsync: CloudWatchAsyncClient = CloudWatchAsyncClient
       .builder

--- a/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
@@ -3,28 +3,50 @@ package com.krux.starport.metric
 import java.util.concurrent.TimeUnit
 
 import scala.util.Random
-
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
-import com.codahale.metrics.{MetricRegistry, ScheduledReporter, ConsoleReporter}
-//import io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter
-
+import com.codahale.metrics.{ConsoleReporter, MetricFilter, MetricRegistry, ScheduledReporter}
+import io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter
+import io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter.Percentile
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import com.typesafe.config.Config
 
-sealed trait MetricSettings extends Serializable {
+/**
+ * A service trait that used by private case class constructors.
+ */
+trait MetricSettingsImpl extends Serializable {
+
+  def getReporter(registry: MetricRegistry): ScheduledReporter
 
 }
 
-case object GraphiteReporterSettings extends MetricSettings {
+/**
+ * A sealed trait for metric engine settings. We want this to be sealed as there should only be a finite number of
+ * reporting engine options available.
+ */
+sealed trait MetricSettings {
 
+  /** Set the default duration to be in seconds */
   final val DefaultDuration = TimeUnit.SECONDS
 
-  def getReporter(configOpt: Option[Config], registry: MetricRegistry): ScheduledReporter =
-    configOpt.map(GraphiteReporterSettingsImpl(_).getReporter(registry))
-      .getOrElse(
-        ConsoleReporter.forRegistry(registry).convertDurationsTo(DefaultDuration).build()
-      )
+  def getReporter(config: Config, registry: MetricRegistry): ScheduledReporter = this match {
+      case GraphiteReporterSettings => GraphiteReporterSettings(config).getReporter(registry)
+      case CloudWatchReporterSettings => CloudWatchReporterSettings(config).getReporter(registry)
+  }
 
-  private case class GraphiteReporterSettingsImpl(config: Config) extends MetricSettings {
+  def getDefaultReporter(registry: MetricRegistry): ScheduledReporter = ConsoleReporter
+    .forRegistry(registry)
+    .convertDurationsTo(DefaultDuration)
+    .build()
+
+}
+
+final case object GraphiteReporterSettings extends MetricSettings {
+
+  def apply(config: Config): MetricSettingsImpl = GraphiteReporterSettingsImpl(config)
+
+  private case class GraphiteReporterSettingsImpl(config: Config) extends MetricSettingsImpl {
 
     val hosts = config.getStringList("hosts")
 
@@ -35,11 +57,50 @@ case object GraphiteReporterSettings extends MetricSettings {
     def getGraphite: Graphite =
       new Graphite(hosts.get(Random.nextInt(hosts.size)), port)
 
-    def getReporter(registry: MetricRegistry): ScheduledReporter = GraphiteReporter.forRegistry(registry)
+    def getReporter(registry: MetricRegistry): ScheduledReporter = GraphiteReporter
+      .forRegistry(registry)
       .prefixedWith(metricPrefix)
-      .convertDurationsTo(GraphiteReporterSettings.DefaultDuration)
+      .convertDurationsTo(DefaultDuration)
       .build(getGraphite)
 
   }
 
 }
+
+final case object CloudWatchReporterSettings extends MetricSettings {
+
+  def apply(config: Config): MetricSettingsImpl = CloudWatchReporterSettingsImpl(config)
+
+  private case class CloudWatchReporterSettingsImpl(config: Config) extends MetricSettingsImpl {
+
+    def awsCloudWatchAsync: CloudWatchAsyncClient = CloudWatchAsyncClient
+      .builder
+      .region(config.getConfig("region").toString.asInstanceOf[Region])
+      .build
+
+    def getReporter(metricRegistry: MetricRegistry): CloudWatchReporter = CloudWatchReporter
+      .forRegistry(metricRegistry, awsCloudWatchAsync, classOf[Nothing].getName)
+      .convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS)
+      .filter(MetricFilter.ALL)
+      .withPercentiles(Percentile.P75, Percentile.P99)
+      .withOneMinuteMeanRate
+      .withFiveMinuteMeanRate
+      .withFifteenMinuteMeanRate
+      .withMeanRate
+      .withArithmeticMean
+      .withStdDev
+      .withStatisticSet
+      .withZeroValuesSubmission
+      .withReportRawCountValue
+      .withHighResolution
+      .withMeterUnitSentToCW(StandardUnit.BYTES)
+      .withJvmMetrics
+      .withGlobalDimensions("Region=us-west-2", "Instance=stage")
+      .withDryRun
+      .build
+
+  }
+
+}
+
+

--- a/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
@@ -74,7 +74,7 @@ final case object CloudWatchReporterSettings extends MetricSettings {
   private case class CloudWatchReporterSettingsImpl(config: Config) extends MetricSettingsImpl {
 
     val awsRegion: Region = Region.of(config.getString("region"))
-    val awsEnvironment = config.getString("environment")
+    val prefix = config.getString("krux.starport.prefix")
 
     val awsCloudWatchAsync: CloudWatchAsyncClient = CloudWatchAsyncClient
       .builder
@@ -98,8 +98,7 @@ final case object CloudWatchReporterSettings extends MetricSettings {
       .withHighResolution
       .withMeterUnitSentToCW(StandardUnit.BYTES)
       .withJvmMetrics
-      .withGlobalDimensions(s"Region=${awsRegion}", s"Instance=${awsEnvironment}")
-      .withDryRun
+      .withGlobalDimensions(s"Environment=s{$prefix}")
       .build
 
   }

--- a/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
@@ -73,7 +73,7 @@ final case object CloudWatchReporterSettings extends MetricSettings {
 
   private case class CloudWatchReporterSettingsImpl(config: Config) extends MetricSettingsImpl {
 
-    val awsRegion: Region = config.getString("region").asInstanceOf[Region]
+    val awsRegion: Region = Region.of(config.getString("region"))
     val awsEnvironment = config.getString("environment")
 
     val awsCloudWatchAsync: CloudWatchAsyncClient = CloudWatchAsyncClient

--- a/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
+++ b/starport-core/src/main/scala/com/krux/starport/metric/MetricSettings.scala
@@ -6,35 +6,40 @@ import scala.util.Random
 
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.codahale.metrics.{MetricRegistry, ScheduledReporter, ConsoleReporter}
+//import io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter
 
 import com.typesafe.config.Config
 
-
-class MetricSettings(val config: Config) extends Serializable {
-
-  val hosts = config.getStringList("hosts")
-
-  val port = config.getInt("port")
-
-  val metricPrefix = config.getString("prefix")
-
-  def getGraphite: Graphite =
-    new Graphite(hosts.get(Random.nextInt(hosts.size)), port)
-
-  def getReporter(registry: MetricRegistry): ScheduledReporter = GraphiteReporter.forRegistry(registry)
-    .prefixedWith(metricPrefix)
-    .convertDurationsTo(MetricSettings.DefaultDuration)
-    .build(getGraphite)
+sealed trait MetricSettings extends Serializable {
 
 }
 
-object MetricSettings {
+case object GraphiteReporterSettings extends MetricSettings {
 
   final val DefaultDuration = TimeUnit.SECONDS
 
   def getReporter(configOpt: Option[Config], registry: MetricRegistry): ScheduledReporter =
-    configOpt.map(new MetricSettings(_).getReporter(registry))
+    configOpt.map(GraphiteReporterSettingsImpl(_).getReporter(registry))
       .getOrElse(
         ConsoleReporter.forRegistry(registry).convertDurationsTo(DefaultDuration).build()
       )
+
+  private case class GraphiteReporterSettingsImpl(config: Config) extends MetricSettings {
+
+    val hosts = config.getStringList("hosts")
+
+    val port = config.getInt("port")
+
+    val metricPrefix = config.getString("prefix")
+
+    def getGraphite: Graphite =
+      new Graphite(hosts.get(Random.nextInt(hosts.size)), port)
+
+    def getReporter(registry: MetricRegistry): ScheduledReporter = GraphiteReporter.forRegistry(registry)
+      .prefixedWith(metricPrefix)
+      .convertDurationsTo(GraphiteReporterSettings.DefaultDuration)
+      .build(getGraphite)
+
+  }
+
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.12.0"
+version in ThisBuild := "5.13.0"


### PR DESCRIPTION
This PR turns the `MetricSettings` object into a sealed trait, which is then inherited by the case objects `GraphiteReporterSettings` and `CloudWatchReporterSettings`. The selection of the reporting engine is controlled via the `metricsEngine` key in `StarportSettings`.