### PR TITLE
Add SummarizeUnmanagedPipelines activity

### DIFF
--- a/starport-core/src/main/scala/com/krux/starport/StarportActivity.scala
+++ b/starport-core/src/main/scala/com/krux/starport/StarportActivity.scala
@@ -1,6 +1,9 @@
 package com.krux.starport
 
+import slick.jdbc.PostgresProfile.api._
+
 import com.krux.starport.config.StarportSettings
+import com.krux.starport.db.table.ScheduledPipelines
 import com.krux.starport.db.{DateTimeMapped, WaitForIt}
 import com.krux.starport.util.DateTimeFunctions
 
@@ -12,5 +15,16 @@ trait StarportActivity extends DateTimeMapped with WaitForIt with Logging with D
 
   def db = conf.jdbc.db
   val parallel = conf.parallel
+
+  def inConsoleManagedPipelineIds(): Set[String] = {
+    val pipelineIds = db.run(
+      ScheduledPipelines()
+        .filter(_.inConsole)
+        .distinctOn(_.awsId)
+        .result
+    ).waitForResult.map(_.awsId).toSet
+    logger.info(s"Retrieved ${pipelineIds.size} in-console managed pipelines from Starport DB.")
+    pipelineIds
+  }
 
 }

--- a/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
@@ -14,12 +14,9 @@ object SummarizeUnmanagedPipelines extends StarportActivity {
 
     logger.info("Unmanaged Pipeline Count By Date:")
     pipelineStatuses.values
-      .map { status =>
-        val date = status.creationTime.flatMap(_.split("T").headOption).getOrElse("Unknown")
-        (date, 1)
-      }
-      .groupBy(_._1)
-      .mapValues(_.map(_._2).sum)
+      .map(status => status.creationTime.flatMap(_.split("T").headOption).getOrElse("Unknown"))
+      .groupBy(identity)
+      .mapValues(_.size)
       .toSeq
       .sortBy(_._1)(Ordering[String].reverse)
       .foreach { case (date, count) => logger.info(s"$date -> $count") }

--- a/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
@@ -9,8 +9,20 @@ object SummarizeUnmanagedPipelines extends StarportActivity {
     val pipelineStatuses = AwsDataPipeline.describePipeline(pipelinesInAws.toSeq: _*)
 
     logger.info("Unmanaged Pipeline Count By State:")
-    pipelineStatuses.groupBy(_._2.pipelineState).mapValues(_.size).toSeq.sortBy(_._2)(Ordering[Int].reverse)
+    pipelineStatuses.values.groupBy(_.pipelineState).mapValues(_.size).toSeq.sortBy(_._2)(Ordering[Int].reverse)
       .foreach { case (state, count) => logger.info(s"${state.getOrElse("Unknown")} -> $count") }
+
+    logger.info("Unmanaged Pipeline Count By Date:")
+    pipelineStatuses.values
+      .map { status =>
+        val date = status.creationTime.flatMap(_.split("T").headOption).getOrElse("Unknown")
+        (date, 1)
+      }
+      .groupBy(_._1)
+      .mapValues(_.map(_._2).sum)
+      .toSeq
+      .sortBy(_._1)(Ordering[String].reverse)
+      .foreach { case (date, count) => logger.info(s"$date -> $count") }
   }
 
   def main(args: Array[String]): Unit = {

--- a/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
@@ -1,0 +1,23 @@
+package com.krux.starport
+
+import com.krux.starport.util.AwsDataPipeline
+
+object SummarizeUnmanagedPipelines extends StarportActivity {
+
+  def run(): Unit = {
+    val pipelinesInAws = AwsDataPipeline.listPipelineIds() -- inConsoleManagedPipelineIds()
+    val pipelineStatuses = AwsDataPipeline.describePipeline(pipelinesInAws.toSeq: _*)
+
+    logger.info("Unmanaged Pipeline Count By State:")
+    pipelineStatuses.groupBy(_._2.pipelineState).mapValues(_.size).toSeq.sortBy(_._2)(Ordering[Int].reverse)
+      .foreach { case (state, count) => logger.info(s"$state -> $count") }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val start = System.nanoTime()
+    run()
+    val timeSpan = (System.nanoTime - start) / 1E9
+    logger.info(s"Done in $timeSpan seconds")
+  }
+
+}

--- a/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/SummarizeUnmanagedPipelines.scala
@@ -10,7 +10,7 @@ object SummarizeUnmanagedPipelines extends StarportActivity {
 
     logger.info("Unmanaged Pipeline Count By State:")
     pipelineStatuses.groupBy(_._2.pipelineState).mapValues(_.size).toSeq.sortBy(_._2)(Ordering[Int].reverse)
-      .foreach { case (state, count) => logger.info(s"$state -> $count") }
+      .foreach { case (state, count) => logger.info(s"${state.getOrElse("Unknown")} -> $count") }
   }
 
   def main(args: Array[String]): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.11.0"
+version in ThisBuild := "5.11.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.11.1"
+version in ThisBuild := "5.12.0"


### PR DESCRIPTION
To print `State -> Count` for the pipelines that are not managed by Starport.

Sample run and output:
```
sbt "core/runMain com.krux.starport.SummarizeUnmanagedPipelines"
...
[error] INFO  13:42:27 [main] c.k.s.SummarizeUnmanagedPipelines$ - Unmanaged Pipeline Count By State:
[error] INFO  13:42:27 [main] c.k.s.SummarizeUnmanagedPipelines$ - FINISHED -> 137
[error] INFO  13:42:27 [main] c.k.s.SummarizeUnmanagedPipelines$ - SCHEDULED -> 1
[error] INFO  13:42:27 [main] c.k.s.SummarizeUnmanagedPipelines$ - Done in 41.904728902 seconds
[success] Total time: 49 s, completed Dec 12, 2019 1:42:27 PM
```