### PR TITLE
Add close command to end of jobs using reporter engines

### DIFF
--- a/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/CleanupExistingPipelines.scala
@@ -171,6 +171,7 @@ object CleanupExistingPipelines extends StarportActivity {
       )
     } finally {
       reporter.report()
+      reporter.close()
     }
   }
 

--- a/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
+++ b/starport-core/src/main/scala/com/krux/starport/StartScheduledPipelines.scala
@@ -280,6 +280,7 @@ object StartScheduledPipelines extends StarportActivity {
     } finally {
       mainTimer.stop()
       reporter.report()
+      reporter.close()
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.13.0"
+version in ThisBuild := "5.13.1"


### PR DESCRIPTION
Cloudwatch requires the `close` method to be called to exit gracefully.